### PR TITLE
comment bug fix

### DIFF
--- a/frontend/app/assets/css/bootstrap/less/popovers.less
+++ b/frontend/app/assets/css/bootstrap/less/popovers.less
@@ -9,7 +9,6 @@
   left: 0;
   z-index: @zindex-popover;
   display: none;
-  max-width: @popover-max-width;
   padding: 1px;
   // Our parent element can be arbitrary since popovers are by default inserted as a sibling of their target element.
   // So reset our font and text properties to avoid inheriting weird values.


### PR DESCRIPTION
в реакт версии компонент создается без специального css класса на .popover , в jquery версии у него на этот .popover добавляются классы editable-container editable-popup, которые и дают возможность тянуть это окно,  я убрала стиль, который мешает на самом .popover, пока других popover кроме коммента нет, это решение допустимо
