### PR TITLE
Added BOM mark to force Excel to use UTF-8.

### DIFF
--- a/frontend/app/utils/export/ExporterBase.js
+++ b/frontend/app/utils/export/ExporterBase.js
@@ -30,6 +30,6 @@ export default class ExporterBase {
 
         const documentBody = this.buildDocument(headerRow, rows);
         const blobType = `"${this.mimeType}"`;
-        return new Blob([documentBody], {type: blobType});
+        return new Blob(['\uFEFF' + documentBody], {type: blobType});
     }
 }


### PR DESCRIPTION
Протестировано в линуксовых редакторах и WinXP WordPad (:exclamation:), в них всё ок. Excel у меня нет.
