### PR TITLE
issue 272: show slightly different hints for filters and views

### DIFF
--- a/frontend/app/components/Modals/FilterBuilder/ExistentFilterSelect.js
+++ b/frontend/app/components/Modals/FilterBuilder/ExistentFilterSelect.js
@@ -27,7 +27,7 @@ export default class ExistentFilterSelect extends Component {
         const title = (auth.isDemo) ? 'Login or register to work with filter' : 'Make a copy for editing';
         const isFilterEditable = (selectedFilter.type === 'user');
 
-        const descriptionText = getReadonlyReasonForSessionAndType(auth.isDemo, selectedFilter.type);
+        const descriptionText = getReadonlyReasonForSessionAndType('filter', auth.isDemo, selectedFilter.type);
         
         return (
 

--- a/frontend/app/components/Modals/ViewBuilder/ExistentViewSelect.js
+++ b/frontend/app/components/Modals/ViewBuilder/ExistentViewSelect.js
@@ -45,7 +45,7 @@ export default class ExistentViewSelect extends React.Component {
     }
 
     renderDescription(isDemoSession, selectedViewType) {
-        const descriptionText = getReadonlyReasonForSessionAndType(isDemoSession, selectedViewType);
+        const descriptionText = getReadonlyReasonForSessionAndType('view', isDemoSession, selectedViewType);
 
         if (descriptionText) {
             return (

--- a/frontend/app/utils/stringUtils.js
+++ b/frontend/app/utils/stringUtils.js
@@ -28,12 +28,12 @@ export function getItemLabelByNameAndType(itemName, itemType) {
     return itemType === 'history' ? itemName + ' (from history)' : itemName;
 }
 
-export function getReadonlyReasonForSessionAndType(isDemoSession, selectedViewFilterType) {
-    var descriptionText = 'This view is not editable, duplicate it to make changes.';
+export function getReadonlyReasonForSessionAndType(what, isDemoSession, selectedViewFilterType) {
+    var descriptionText = 'This ' + what + ' is not editable, duplicate it to make changes.';
     descriptionText = isDemoSession ? descriptionText + ' (Only for registered users)' : descriptionText;
     switch (selectedViewFilterType) {
         case 'history':
-            descriptionText = 'This view is history view, duplicate it to make changes.';
+            descriptionText = 'This ' + what + ' is history ' + what + ', duplicate it to make changes.';
             break;
         case 'user':
             descriptionText = '';


### PR DESCRIPTION
#272

Для фильтров показываем 'filter', для вью - 'view' в подсказке о том, почему не редактируется
