### PR TITLE
Исправлен баг в поддержке запятых в фильтрах

### DIFF
--- a/services/SearchService.js
+++ b/services/SearchService.js
@@ -264,7 +264,7 @@ class SearchService extends ServiceBase {
             });
         } else {
             const strOld = ruleObj.value;
-            if (strOld) {
+            if (typeof strOld === 'string' && strOld) {
                 ruleObj.value = strOld.replace(/,/g, '\\x2c');
             }
         }


### PR DESCRIPTION
Значения правил фильтров могут быть не только строками. Добавлена проверка, что тип значения - строка, перед заменой ','->'\x2c'. #426 