### PR TITLE
Fixed auto loading when results size is multiple of 100.

### DIFF
--- a/frontend/app/actions/variantsTable.js
+++ b/frontend/app/actions/variantsTable.js
@@ -248,10 +248,11 @@ function requestSearchedResults(flags) {
     };
 }
 
-export function receiveSearchedResults() {
+export function receiveSearchedResults(isReceivedAll) {
     return {
         type: RECEIVE_SEARCHED_RESULTS,
-        receivedAt: Date.now()
+        receivedAt: Date.now(),
+        isReceivedAll
     };
 }
 

--- a/frontend/app/actions/websocket.js
+++ b/frontend/app/actions/websocket.js
@@ -138,9 +138,10 @@ function receiveSearchMessage(wsData) {
     return (dispatch, getState) => {
         if (wsData.result.status === WS_PROGRESS_STATUSES.READY) {
             dispatch(tableMessage(wsData));
-            const {variantsTable} = getState();
+            const {variantsTable, variantsTable: {searchInResultsParams: {limit}}} = getState();
             if (variantsTable.isFilteringOrSorting || variantsTable.isNextDataLoading) {
-                dispatch(receiveSearchedResults());
+                const isReceivedAll = wsData.result.data && wsData.result.data.length < limit;
+                dispatch(receiveSearchedResults(isReceivedAll));
             }
         } else {
             dispatch(progressMessage(wsData));

--- a/frontend/app/reducers/variantsTable.js
+++ b/frontend/app/reducers/variantsTable.js
@@ -23,6 +23,7 @@ const initialState = {
     needUpdate: false,
     isNextDataLoading: false,
     isFilteringOrSorting: false,
+    isReceivedAll: false,
     selectedRowIndices: []
 };
 
@@ -174,7 +175,8 @@ export default function variantsTable(state = initialState, action) {
                 isNextDataLoading: false,
                 isFilteringOrSorting: false,
                 isFetching: false,
-                lastUpdated: action.receivedAt
+                lastUpdated: action.receivedAt,
+                isReceivedAll: action.isReceivedAll
             });
         }
         case ActionTypes.SELECT_VARIANTS_ROW: {

--- a/frontend/app/reducers/websocket.js
+++ b/frontend/app/reducers/websocket.js
@@ -54,13 +54,12 @@ function reduceAddComment(action, state) {
 
 function reduceTableMessage(action, state) {
     const resultData = action.wsData.result.data;
+    const newVariants = state.variants === null ? resultData : [...state.variants, ...(resultData || [])];
     return Object.assign({}, state, {
-        variants: state.variants === null ?
-            resultData :
-            [...state.variants, ...(resultData || [])],
+        variants: newVariants,
         variantsHeader: action.wsData.result.header,
         currentVariants: resultData,
-        isVariantsEmpty: (resultData && resultData.length === 0),
+        isVariantsEmpty: (newVariants && newVariants.length === 0),
         isVariantsLoading: false,
         isVariantsValid: true,
         variantsError: null


### PR DESCRIPTION
#647 
1. Исправлено вычисление websocket.isVariantsEmpty: раньше проверялся размер последней полученной части результатов (currentVariants), а теперь проверяется размер всех полученных результатов (variants).
2. Добавлен флаг variantsTable.isReceivedAll как признак окончания данных для загрузки (по аналогии со списком анализов в окне Analyses). Если этот признак установлен, то элемент loading внизу таблицы не рендерится.