### PR TITLE
Исправления в окне с комментарием

### DIFF
--- a/frontend/app/assets/css/less/agx-bootstrap-components/popovers.less
+++ b/frontend/app/assets/css/less/agx-bootstrap-components/popovers.less
@@ -3,6 +3,9 @@
 .popover {
   max-width:none;
   .box-shadow(@popover-shadow);
+  .arrow {
+    display: none !important;
+  }
 
   @media (max-width: @screen-xxs-max) {
     left: 0 !important;
@@ -11,9 +14,6 @@
     right: 0 !important;
     top: @navbar-height !important;
     position: fixed;
-    .arrow {
-      display: none !important;
-    }
     .popover-content {
       background: #fff ;
       position: relative;

--- a/frontend/app/assets/css/less/agx-bootstrap-components/tables.less
+++ b/frontend/app/assets/css/less/agx-bootstrap-components/tables.less
@@ -1,6 +1,8 @@
 // Overwriten bootstrap styles for table
 .table-row-variant(active; @table-bg-active);
 
+.table-row-variant(highlighted; @table-bg-highlighted);
+
 .table {
   tbody{
     tr {

--- a/frontend/app/assets/css/less/agx-bootstrap-components/variables.less
+++ b/frontend/app/assets/css/less/agx-bootstrap-components/variables.less
@@ -129,6 +129,8 @@
 //** Background color used for `.table-hover`.
 @table-bg-hover:               lighten(#f6f7f9, 1%);
 @table-bg-active:               darken(@table-bg-accent,3%);
+//** Background color used for highlight state
+@table-bg-highlighted:          #ffff99;
 
 //** Border color for table and cell borders.
 @table-border-color:           lighten(#f6f7f9, 1%);

--- a/frontend/app/components/VariantsTable/VariantsTableComment.js
+++ b/frontend/app/components/VariantsTable/VariantsTableComment.js
@@ -39,11 +39,18 @@ export default class VariantsTableComment extends Component {
                         ref='overlay'
                         rootClose={true}
                         placement='right'
+                        container={this.props.tableElement}
                         overlay={
                             <Popover id={searchKey}>
                                 {this.renderCommentPopover()}
                             </Popover>
                         }
+                        onEnter={() => {
+                            this.props.onPopupTriggered(true);
+                        }}
+                        onExiting={() => {
+                            this.props.onPopupTriggered(false);
+                        }}
                     >
                         <div>
                             <a className='btn-link-default editable editable-pre-wrapped editable-click editable-open'>

--- a/frontend/app/components/VariantsTable/VariantsTableRow.js
+++ b/frontend/app/components/VariantsTable/VariantsTableRow.js
@@ -12,6 +12,13 @@ import {Popover, OverlayTrigger} from 'react-bootstrap';
 
 
 export default class VariantsTableRow extends ComponentBase {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isHighlighted: false
+        };
+    }
+
     render() {
         const {
             dispatch,
@@ -33,7 +40,7 @@ export default class VariantsTableRow extends ComponentBase {
         const searchKey = row.searchKey;
 
         return (
-            <tr>
+            <tr className={classNames({'highlighted': this.state.isHighlighted})}>
                 <td className='btntd row_checkbox'>
                     <div>{rowIndex + 1}</div>
                 </td>
@@ -62,12 +69,20 @@ export default class VariantsTableRow extends ComponentBase {
                                       dispatch={dispatch}
                                       auth={auth}
                                       comments={comments}
+                                      tableElement={this.props.tableElement}
+                                      onPopupTriggered={(isHighlighted) => this.setHighlighted(isHighlighted)}
                 />
                 {_.map(rowFields, (value, index) =>
                     this.renderFieldValue(index, variantsHeader[index].fieldId, variantsHeader[index].sampleId, value, sortState)
                 )}
             </tr>
         );
+    }
+
+    setHighlighted(isHighlighted) {
+        this.setState({
+            isHighlighted
+        });
     }
 
     onRowSelectionChanged() {
@@ -189,9 +204,10 @@ export default class VariantsTableRow extends ComponentBase {
             && value !== '.';
     }
 
-    shouldComponentUpdate(nextProps) {
+    shouldComponentUpdate(nextProps, nextState) {
         return this.props.row !== nextProps.row
-            || this.props.isSelected !== nextProps.isSelected;
+            || this.props.isSelected !== nextProps.isSelected
+            || this.state !== nextState;
     }
 }
 


### PR DESCRIPTION
#797 
1. Убран уголок, указывающий на редактируемую строчку. Вместо этого добавлена подсветка строки;
2. Окно с комментарием "привязано" к своей строке и передвигается за ней при скроллинге.