### PR TITLE
#751: fix bug duplicated sample (cherry-picked from langu-support).

### DIFF
--- a/controllers/SampleController.js
+++ b/controllers/SampleController.js
@@ -51,19 +51,14 @@ class SampleController extends UserEntityControllerBase {
                     fileSize: sampleFile.size,
                     originalFileName: fileName
                 };
-                this.services.samples.upload(session, user, fileInfo, (error, operationId) => {
+                this.services.samples.upload(session, user, fileInfo, sampleList, (error, operationId, sampleIds) => {
                     // Try removing local file anyway.
                     this._removeSampleFile(fileInfo.localFilePath);
-                    callback(error, operationId, sampleList);
+                    callback(error, operationId, sampleIds);
                 });
             },
-            (operationId, sampleList, callback) => {
+            (operationId, sampleIds, callback) => {
                 this.services.sampleUploadHistory.find(user, operationId, (error, upload) => {
-                    callback(error, operationId, upload, sampleList);
-                });
-            },
-            (operationId, upload, sampleList, callback) => {
-                this.services.samples.initMetadataForUploadedSample(user, upload.id, upload.fileName, sampleList, null, (error, sampleIds) => {
                     callback(error, operationId, upload, sampleIds);
                 });
             },


### PR DESCRIPTION
Последовательность действий при аплоаде была следующая:
1. вызов аплоада на AS
2. запись в базу сэмплов, распарсенных на WS.
Это приводило к тому, что от AS мог придти и записаться в базу список сэмплов, раньше, чем будет записан список сэмплов, распарсенных на WS. В итоге, получался двойной списко сэмплов.

Пулл-реквест исправляет порядок действий:
1. запись в базу списка сэмплов, полученных на WS
2. аплод на AS
3. обновление в базе информации о сэмплах после окончания аплода на AS.