### PR TITLE
875 make robust upload service

### DIFF
--- a/services/external/applicationServer/AppServerUploadService.js
+++ b/services/external/applicationServer/AppServerUploadService.js
@@ -94,6 +94,13 @@ function makeAsyncQueue() {
     };
 }
 
+function callbackErrorHandler(fn, callback) {
+    try {
+        fn()
+    } catch (err) {
+        callback(err);
+    }
+}
 
 class AppServerUploadService extends ApplicationServerServiceBase {
     constructor(services, models) {
@@ -224,31 +231,42 @@ class AppServerUploadService extends ApplicationServerServiceBase {
 
     _handleError(user, operation, error, session, callback) {
         async.waterfall([
-            (callback) => this.services.sampleUploadHistory.update(user, {
-                id: operation.getId(),
-                status: SAMPLE_UPLOAD_STATUS.ERROR,
-                error
-            }, (error) => callback(error)),
             (callback) => {
-                const {newSamplesBucket} = this.services.objectStorage.getStorageSettings();
-                const vcfFileId = operation.getId();
-                this.services.objectStorage.deleteObject(newSamplesBucket, vcfFileId,
-                    (error, result) => callback(error)
-                );
-            },
-            (callback) => this.services.samples.theModel.findSamplesByVcfFileIds(user.id, [operation.getId()], true,
-                (error, existingSamples) => callback(error, existingSamples)),
-            (existingSamples, callback) => {
-                const sampleUploadStates = _.map(existingSamples, (sample) => {
-                    return Object.assign({}, sample, {
-                        uploadState: WS_SAMPLE_UPLOAD_STATE.ERROR,
+                callbackErrorHandler(() => {
+                    this.services.sampleUploadHistory.update(user, {
+                        id: operation.getId(),
+                        status: SAMPLE_UPLOAD_STATUS.ERROR,
                         error
-                    });
-                });
-                async.map(sampleUploadStates, (sample, callback) => {
-                    return this.services.samples.update(user, sample, callback);
-                }, (error, result) => callback(error, result));
+                    }, (error) => callback(error));
+                }, callback);
             },
+            (callback) => {
+                callbackErrorHandler(() => {
+                    const {newSamplesBucket} = this.services.objectStorage.getStorageSettings();
+                    const vcfFileId = operation.getId();
+                    this.services.objectStorage.deleteObject(newSamplesBucket, vcfFileId,
+                        (error, result) => callback(error));
+                }, callback);
+            },
+            (callback) => {
+                callbackErrorHandler(() => {
+                    this.services.samples.theModel.findSamplesByVcfFileIds(user.id, [operation.getId()], true,
+                        (error, existingSamples) => callback(error, existingSamples));
+                }, callback);
+            },
+            (existingSamples, callback) => {
+                callbackErrorHandler(() => {
+                    const sampleUploadStates = _.map(existingSamples, (sample) => {
+                        return Object.assign({}, sample, {
+                            uploadState: WS_SAMPLE_UPLOAD_STATE.ERROR,
+                            error
+                        });
+                    });
+                    async.map(sampleUploadStates, (sample, callback) => {
+                        return this.services.samples.update(user, sample, callback);
+                    }, (error, result) => callback(error, result));
+                }, callback);
+            }
         ], () => {
             async.waterfall([
                 (callback) => this.toggleNextOperation(operation.getId(), callback),
@@ -329,16 +347,27 @@ class AppServerUploadService extends ApplicationServerServiceBase {
         const commonFieldsMetadata = sampleMetadata.columns;
 
         async.waterfall([
-            (callback) => this.services.samples.createMetadataForUploadedSample(user, vcfFileId, commonFieldsMetadata,
-                (error, sampleVersionIds) => callback(error, sampleVersionIds)
-            ),
-            (sampleIds, callback) => this.services.samples.findMany(user, sampleIds, callback),
-            (samplesMetadata, callback) => this.services.sampleUploadHistory.update(user, {
-                id: operation.getId(),
-                status: SAMPLE_UPLOAD_STATUS.READY,
-                progress: 100,
-                error: null
-            }, (error) => callback(error, samplesMetadata))
+            (callback) => {
+                callbackErrorHandler(() => {
+                    this.services.samples.createMetadataForUploadedSample(user, vcfFileId, commonFieldsMetadata,
+                        (error, sampleVersionIds) => callback(error, sampleVersionIds));
+                }, callback);
+            },
+            (sampleIds, callback) => {
+                callbackErrorHandler(() => {
+                    this.services.samples.findMany(user, sampleIds, callback);
+                }, callback);
+            },
+            (samplesMetadata, callback) => {
+                callbackErrorHandler(() => {
+                    this.services.sampleUploadHistory.update(user, {
+                        id: operation.getId(),
+                        status: SAMPLE_UPLOAD_STATUS.READY,
+                        progress: 100,
+                        error: null
+                    }, (error) => callback(error, samplesMetadata));
+                }, callback);
+            }
         ], (error, samplesMetadata) => {
             if (error) {
                 this.logger.error(`Error inserting new sample into database: ${error}`);


### PR DESCRIPTION
#875 
Сделан более надежным код, который производит переключение обработки очереди загружаемых файлов на AS:
1. В методе _handleError() перенесены вызовы toggleNextOperation и _createOperationResult в финальный callback конструкции waterfall, чтобы они были вызваны независимо от того, успешно или нет была выполнена цепочка функций, входящих в waterfall. В методе _completeUpload() уже сделано таким же образом.
2. В каждой функции внутри waterfall внутри методов _handleError() и _completeUpload() добавлен код, который отлавливает и передает исплючения в виде ошибки callback(error).

Рефакторинг:
3. Убрана избыточная конструкция waterfall из _completeUpload(), т.к. внутри него выполняется всего одна функция.


Как проверять:
1. Имитируем неудачное выполнение записи в базу.
Удалить последнюю миграцию /home/andrey/work/sources/gen-bs/database/migrations/20170208165444_fix-sample-error-type.js и выполнить загрузку файла из #873. 
_Ожидается:_ ошибка о том, что файл не может быть распарсен не записана в базу, но очередь обработки загружаемых файлов не "затыкается". Пользователь может продолжать загружать файлы.

2. В произвольном месте в функциях _handleError() и _completeUpload() расставляем throw.